### PR TITLE
Rename Object to Element as Object is a reserved name

### DIFF
--- a/Trello/Model/Action.php
+++ b/Trello/Model/Action.php
@@ -2,7 +2,7 @@
 
 namespace Trello\Model;
 
-class Action extends Object {
+class Action extends Element {
 
     protected $_model = 'actions';
 

--- a/Trello/Model/Board.php
+++ b/Trello/Model/Board.php
@@ -2,7 +2,7 @@
 
 namespace Trello\Model;
 
-class Board extends Object {
+class Board extends Element {
 
     protected $_model = 'boards';
 

--- a/Trello/Model/Card.php
+++ b/Trello/Model/Card.php
@@ -2,7 +2,7 @@
 
 namespace Trello\Model;
 
-class Card extends Object {
+class Card extends Element {
 
     protected $_model = 'cards';
 
@@ -35,7 +35,7 @@ class Card extends Object {
         keepFromSource (optional)
         Default: all
         Valid Values: Properties of the card to copy over from the source.
-     * @see \Trello\Model\Object::save()
+     * @see \Trello\Model\Element::save()
      */
     public function save(){
 

--- a/Trello/Model/Element.php
+++ b/Trello/Model/Element.php
@@ -2,7 +2,7 @@
     
 namespace Trello\Model;
 
-abstract class Object implements \ArrayAccess, \Countable, \Iterator{
+abstract class Element implements \ArrayAccess, \Countable, \Iterator{
 
     protected $_client;
     protected $_model;
@@ -20,7 +20,7 @@ abstract class Object implements \ArrayAccess, \Countable, \Iterator{
     /**
      * Save an object
      *
-     * @return \Trello\Model\Object
+     * @return \Trello\Model\Element
      */
     public function save(){
 
@@ -54,7 +54,7 @@ abstract class Object implements \ArrayAccess, \Countable, \Iterator{
      * Get an item by id ($this->id)
      *
      * @throws \InvalidArgumentException
-     * @return \Trello\Model\Object
+     * @return \Trello\Model\Element
      */
     public function get(){
 

--- a/Trello/Model/Lane.php
+++ b/Trello/Model/Lane.php
@@ -2,7 +2,7 @@
 
 namespace Trello\Model;
 
-class Lane extends Object {
+class Lane extends Element {
 
     protected $_model = 'lists';
 

--- a/Trello/Model/Member.php
+++ b/Trello/Model/Member.php
@@ -2,7 +2,7 @@
 
 namespace Trello\Model;
 
-class Member extends Object {
+class Member extends Element {
 
     protected $_model = 'members';
 

--- a/Trello/Model/Notification.php
+++ b/Trello/Model/Notification.php
@@ -2,7 +2,7 @@
 
 namespace Trello\Model;
 
-class Notification extends Object {
+class Notification extends Element {
 
     protected $_model = 'notifications';
 

--- a/Trello/Model/Organization.php
+++ b/Trello/Model/Organization.php
@@ -2,7 +2,7 @@
 
 namespace Trello\Model;
 
-class Organization extends Object {
+class Organization extends Element {
 
     protected $_model = 'organizations';
 


### PR DESCRIPTION
Starting from PHP 7.2, "Object" is reserved class name, throwing this error:
`Compile Error: Cannot use 'Object' as class name as it is reserved`

I renamed the class "Object" to "Element" to fix this.

Feel free to comment or ask if you questions.