### PR TITLE
Model.php

### DIFF
--- a/Trello/Model/Objects.php
+++ b/Trello/Model/Objects.php
@@ -2,7 +2,7 @@
     
 namespace Trello\Model;
 
-abstract class Object implements \ArrayAccess, \Countable, \Iterator{
+abstract class Model implements \ArrayAccess, \Countable, \Iterator{
 
     protected $_client;
     protected $_model;


### PR DESCRIPTION
Change class name, because "Object" is reserved word in PHP 7.